### PR TITLE
Fix bootstrap file reference; old link is broken

### DIFF
--- a/installed/ubuntu-14.04/Dockerfile
+++ b/installed/ubuntu-14.04/Dockerfile
@@ -7,4 +7,4 @@ RUN apt-get update && \
   apt-get install -y -o DPkg::Options::=--force-confold curl
 
 # Install Latest Salt from the Develop Branch
-RUN curl -L https://bootstrap.saltstack.org | sh -s -- -X git develop
+RUN curl -L https://bootstrap.saltstack.com | sh -s -- -X git develop


### PR DESCRIPTION
$ curl -IL https://bootstrap.saltstack.org 
curl: (7) Failed to connect to bootstrap.saltstack.org port 443: Connection refused
$ curl -IL https://bootstrap.saltstack.com
HTTP/1.1 302 Moved Temporarily
...

This change probably needs to be applied to other Dockerfiles as well.