### PR TITLE
Add support for centos 7 containers

### DIFF
--- a/installed/centos-7/Dockerfile
+++ b/installed/centos-7/Dockerfile
@@ -1,0 +1,8 @@
+from saltstack/centos-7-minimal
+MAINTAINER SaltStack, Inc.
+
+# Update Current Image and install dependencies
+RUN yum update -y && yum install -y --enablerepo=epel curl
+
+# Install Latest Salt from the Develop Branch
+RUN curl -L https://bootstrap.saltstack.com | sh -s -- -X git develop

--- a/installed/centos-7/Makefile
+++ b/installed/centos-7/Makefile
@@ -1,0 +1,38 @@
+REPO           =
+REPOBASE       = $(shell basename $(shell dirname `pwd`))
+CONTAINER_NAME = $(shell basename `pwd`)
+RM             = true
+NO_CACHE       = false
+
+ifeq ($(shell [ "$(REPOBASE)" = "testing" ] && echo 1 || echo 0), 1)
+	REPO=salttest/$(CONTAINER_NAME)
+else ifeq ($(shell [ "$(REPOBASE)" = "installed" ] && echo 1 || echo 0), 1)
+	REPO=saltstack/$(CONTAINER_NAME)
+else ifeq ($(shell [ "$(REPOBASE)" = "minimal" ] && echo 1 || echo 0), 1)
+	REPO=saltstack/$(CONTAINER_NAME)-minimal
+else ifeq ($(shell [ "$(REPOBASE)" = "transifex" ] && echo 1 || echo 0), 1)
+	CONTAINER_NAME=transifex
+	REPO=saltstack/$(CONTAINER_NAME)
+else ifeq ($(shell [ "$(REPOBASE)" = "lint" ] && echo 1 || echo 0), 1)
+	CONTAINER_NAME=lint
+	REPO=salttest/$(CONTAINER_NAME)
+endif
+
+ifndef REPO
+$(error This does not seem like a container root directory)
+endif
+
+all: container
+
+help:
+	@echo "Run 'make container' to build the $(REPO) container"
+
+container:
+	$(info           REPO = $(REPO))
+	$(info       REPOBASE = $(REPOBASE))
+	$(info CONTAINER_NAME = $(CONTAINER_NAME))
+
+	@echo "Building $(REPO) container..."
+	docker build --no-cache=$(NO_CACHE) --rm=$(RM) -t $(REPO) .
+	@echo "Done"
+

--- a/minimal/centos-7/Dockerfile
+++ b/minimal/centos-7/Dockerfile
@@ -1,0 +1,22 @@
+from centos:7
+MAINTAINER SaltStack, Inc.
+
+# Install EPEL
+RUN rpm -Uvh --force http://mirrors.kernel.org/fedora-epel/7/x86_64/e/epel-release-7-9.noarch.rpm
+
+# Update Current Image
+RUN yum install -y libcom_err && yum update -y
+
+# Install Salt Dependencies
+RUN yum -y install --enablerepo=epel \
+  python \
+  PyYAML \
+  m2crypto \
+  python-crypto \
+  python-msgpack \
+  python-zmq \
+  python-setuptools \
+
+RUN easy_install \
+  jinja2 \
+  requests

--- a/minimal/centos-7/Makefile
+++ b/minimal/centos-7/Makefile
@@ -1,0 +1,38 @@
+REPO           =
+REPOBASE       = $(shell basename $(shell dirname `pwd`))
+CONTAINER_NAME = $(shell basename `pwd`)
+RM             = true
+NO_CACHE       = false
+
+ifeq ($(shell [ "$(REPOBASE)" = "testing" ] && echo 1 || echo 0), 1)
+	REPO=salttest/$(CONTAINER_NAME)
+else ifeq ($(shell [ "$(REPOBASE)" = "installed" ] && echo 1 || echo 0), 1)
+	REPO=saltstack/$(CONTAINER_NAME)
+else ifeq ($(shell [ "$(REPOBASE)" = "minimal" ] && echo 1 || echo 0), 1)
+	REPO=saltstack/$(CONTAINER_NAME)-minimal
+else ifeq ($(shell [ "$(REPOBASE)" = "transifex" ] && echo 1 || echo 0), 1)
+	CONTAINER_NAME=transifex
+	REPO=saltstack/$(CONTAINER_NAME)
+else ifeq ($(shell [ "$(REPOBASE)" = "lint" ] && echo 1 || echo 0), 1)
+	CONTAINER_NAME=lint
+	REPO=salttest/$(CONTAINER_NAME)
+endif
+
+ifndef REPO
+$(error This does not seem like a container root directory)
+endif
+
+all: container
+
+help:
+	@echo "Run 'make container' to build the $(REPO) container"
+
+container:
+	$(info           REPO = $(REPO))
+	$(info       REPOBASE = $(REPOBASE))
+	$(info CONTAINER_NAME = $(CONTAINER_NAME))
+
+	@echo "Building $(REPO) container..."
+	docker build --no-cache=$(NO_CACHE) --rm=$(RM) -t $(REPO) .
+	@echo "Done"
+

--- a/testing/centos-7/Dockerfile
+++ b/testing/centos-7/Dockerfile
@@ -1,0 +1,50 @@
+from saltstack/centos-7-minimal
+MAINTAINER SaltStack, Inc.
+
+# Install Salt's Test Suite Dependencies
+#   Required testing build dependencies
+RUN yum install -y --enablerepo=epel \
+  tar \
+  gcc \
+  libffi-devel \
+  openssl-devel \
+  which \
+  python-devel \
+  python-setuptools \
+  python-virtualenv \
+  MySQL-python \
+  ruby \
+  git \
+  subversion \
+  mercurial \
+  openssl \
+  supervisor \
+  rabbitmq-server
+
+#   Requirements only available trough PyPi
+# python26-pip is not available
+RUN easy_install pip
+RUN pip install --upgrade setuptools
+RUN easy_install \
+  mock \
+  timelib \
+  apache-libcloud \
+  unittest2 \
+  coverage \
+  psutil \
+  GitPython \
+  requests \
+  keyring \
+  python-gnupg \
+  CherryPy \
+  tornado \
+  boto \
+  moto \
+  https://github.com/saltstack/salt-testing/archive/develop.tar.gz \
+  https://github.com/danielfm/unittest-xml-reporting/archive/master.tar.gz
+
+ADD https://raw.github.com/saltstack/docker-containers/master/scripts/bootstrap-docker.sh /bootstrap-docker.sh
+
+ENTRYPOINT ["/bin/sh", "/bootstrap-docker.sh", \
+  "/etc/init.d/supervisord start", \
+  "/etc/init.d/rabbitmq-server start"]

--- a/testing/centos-7/Makefile
+++ b/testing/centos-7/Makefile
@@ -1,0 +1,38 @@
+REPO           =
+REPOBASE       = $(shell basename $(shell dirname `pwd`))
+CONTAINER_NAME = $(shell basename `pwd`)
+RM             = true
+NO_CACHE       = false
+
+ifeq ($(shell [ "$(REPOBASE)" = "testing" ] && echo 1 || echo 0), 1)
+	REPO=salttest/$(CONTAINER_NAME)
+else ifeq ($(shell [ "$(REPOBASE)" = "installed" ] && echo 1 || echo 0), 1)
+	REPO=saltstack/$(CONTAINER_NAME)
+else ifeq ($(shell [ "$(REPOBASE)" = "minimal" ] && echo 1 || echo 0), 1)
+	REPO=saltstack/$(CONTAINER_NAME)-minimal
+else ifeq ($(shell [ "$(REPOBASE)" = "transifex" ] && echo 1 || echo 0), 1)
+	CONTAINER_NAME=transifex
+	REPO=saltstack/$(CONTAINER_NAME)
+else ifeq ($(shell [ "$(REPOBASE)" = "lint" ] && echo 1 || echo 0), 1)
+	CONTAINER_NAME=lint
+	REPO=salttest/$(CONTAINER_NAME)
+endif
+
+ifndef REPO
+$(error This does not seem like a container root directory)
+endif
+
+all: container
+
+help:
+	@echo "Run 'make container' to build the $(REPO) container"
+
+container:
+	$(info           REPO = $(REPO))
+	$(info       REPOBASE = $(REPOBASE))
+	$(info CONTAINER_NAME = $(CONTAINER_NAME))
+
+	@echo "Building $(REPO) container..."
+	docker build --no-cache=$(NO_CACHE) --rm=$(RM) -t $(REPO) .
+	@echo "Done"
+


### PR DESCRIPTION
Added docker files to support centos 7
I decided to use the officual centos-7  images for minimal as opposed to from a user.

Tested creation of all three docker containers. Do I need to do any further testing to ensure that I didn't miss anything else ?

